### PR TITLE
Updated System.Runtime.CompilerServices.Unsafe package

### DIFF
--- a/src/BlueRain/packages.config
+++ b/src/BlueRain/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0-preview1-24530-04" targetFramework="net451" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Updated System.Runtime.CompilerServices.Unsafe so the calls to `Unsafe` members in `ExternalProcessMemory` are resolvable.