### PR TITLE
Require administrator permissions only when injecting.

### DIFF
--- a/src/BlueRain/NativeMemory.cs
+++ b/src/BlueRain/NativeMemory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2013-2022 aevitas
+// Copyright (C) 2013-2022 aevitas
 // See the file LICENSE for copying permission.
 
 using System;
@@ -133,9 +133,6 @@ namespace BlueRain
                 return;
 
             Injector?.Dispose();
-
-            // Pretty much all we "have" to clean up.
-            Process.LeaveDebugMode();
 
             IsDisposed = true;
         }


### PR DESCRIPTION
The Process.EnterDebugMode call requires administrator privileges. These are not needed for basic memory read/write operations, but are required for code injection. Therefore, we only call it when injection is needed, allowing regular memory access without prompting the user for elevated permissions.